### PR TITLE
Support newer dart:http, null safety.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,10 +5,10 @@ homepage: https://github.com/apptreesoftware/twirp_dart_core
 author: Matthew Smith<matthew.smith@apptreesoftware.com>
 
 environment:
-  sdk: ">=1.20.1 <3.0.0"
+  sdk: ">=2.12 <3.0.0"
 
 dependencies:
-  http: ^0.12.0
+  http: ^0.13.0
   requester:
     git:
       url: git://github.com/apptreesoftware/requester


### PR DESCRIPTION
No changes required to support null safety, which is nice.

Blocked on either https://github.com/severgroup-tt/requester/pull/2 or https://github.com/apptreesoftware/requester/pull/1